### PR TITLE
No longer update hashes on load_dataset

### DIFF
--- a/cmlkit/dataset/dataset.py
+++ b/cmlkit/dataset/dataset.py
@@ -110,7 +110,7 @@ class Dataset(Configurable):
         splits=[],
         _info=None,
         _hash=None,
-        _geom_hash=None,
+        _geom_hash=None
     ):
         super().__init__()
 
@@ -146,24 +146,20 @@ class Dataset(Configurable):
 
         self.n = len(self.z)
 
-        # perform some consistency checks;
-        # if these ever fail there Is Trouble
-        # (these are supposed to only be written once and never change,
-        # so if they mismatch most likely the hashing method is not as stable
-        # as I thought...)
+        # recent versions of joblib seem to give inconsistent hashes,
+        # so this is most likely not a viable way to proceed
         if _hash is not None:
             this_hash = self.get_hash()
             if _hash != this_hash:
-                logger.warn("saved dataset hash doesn't match, something may be wrong")
-            self.hash = this_hash
+                logger.info("saved dataset hash doesn't match current hash")
+                logger.info("if you didn't change the dataset, run dataset.update_hash() and then save() to get rid of this warning")
+            self.hash = _hash
         else:
             self.hash = self.get_hash()
 
         if _geom_hash is not None:
-            this_hash = self.get_geom_hash()
-            if _geom_hash != this_hash:
-                logger.warn("saved dataset geometry hash doesn't match, something may be wrong")
-            self.geom_hash = this_hash
+            # should be the same warning as above, but seems excessive
+            self.geom_hash = _geom_hash
         else:
             self.geom_hash = self.get_geom_hash()
 
@@ -228,6 +224,11 @@ class Dataset(Configurable):
     def get_geom_hash(self):
         """Hash of only the geometries, ignoring properties etc."""
         return compute_hash(self.z, self.r, self.b)
+    
+    def update_hash(self):
+        """Update hashes."""
+        self.hash = self.get_hash()
+        self.geom_hash = self.get_geom_hash()
 
     def pp(self, target, per="None"):
         return convert(self, self.p[target], per=per)


### PR DESCRIPTION
Apparently, we can no longer expect joblib hashes to be stable, at least for numpy data. So we no longer update it when we load, instead we just keep it as it was saved in the file. This *may* break if stuff gets changed in the file by hand, but that’s probably an edge case we can safely ignore.